### PR TITLE
Mangle TTL on SSDP broadcasts

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -686,6 +686,9 @@ function filter_generate_scrubing() {
 	global $FilterIflist;
 	$scrubrules = "";
 
+	/* GTD: Hook for customizations of scrub rules */
+	$scrubrules .= "include \"/etc/pf/local.scrub.conf\"\n";
+
 	/* see https://redmine.pfsense.org/issues/7801 */
 	if (config_path_enabled('system','vpn_scrubnodf')) {
 		$scrubnodf = "no-df";

--- a/src/etc/pf/README
+++ b/src/etc/pf/README
@@ -1,0 +1,8 @@
+This directory added on 2020-08-09 by Jeff Dairiki <dairiki@dairiki.org>.
+
+/etc/inc/filter.inc has been hacked to include snippets from this directory in the PF rules.
+
+Currently the only supported file is /etc/pf/local.scrub.conf which gets included right before
+the pfSense-generated scrub rules.
+
+

--- a/src/etc/pf/local.scrub.conf
+++ b/src/etc/pf/local.scrub.conf
@@ -1,0 +1,12 @@
+# /etc/pf/local.scrub.conf
+#
+# Local PF scrub rules (configured outside of pfSense)
+# These get included just before all of the pfSense-generated scrub rules.
+
+# SSDP: ensure TTL greater than 1
+#
+# MULTICAST is an interface group containing those interfaces which
+# are participating in multicast routing
+
+scrub in on MULTICAST inet proto udp to 239.255.255.250 port = 1900 min-ttl 2
+


### PR DESCRIPTION
This ensures the TTL on incoming SSDP broadcasts is at least 2.
