### PR TITLE
radvd.conf: only set autonomous flag for /64 nets

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -175,6 +175,7 @@ function services_radvd_configure($blacklist = array()) {
 		} else {
 			$radvdconf .= "\t\tDeprecatePrefix on;\n";
 		}
+		$_adv_autonomous = ($ifcfgsnv6 == 64) ? "on" : "off";
 		switch ($dhcpv6ifconf['ramode']) {
 			case "managed":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
@@ -187,11 +188,11 @@ function services_radvd_configure($blacklist = array()) {
 			case "stateless_dhcp":
 			case "assist":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
-				$radvdconf .= "\t\tAdvAutonomous on;\n";
+				$radvdconf .= "\t\tAdvAutonomous $_adv_autonomous;\n";
 				break;
 			case "unmanaged":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
-				$radvdconf .= "\t\tAdvAutonomous on;\n";
+				$radvdconf .= "\t\tAdvAutonomous $_adv_autonomous;\n";
 				break;
 		}
 
@@ -214,6 +215,7 @@ function services_radvd_configure($blacklist = array()) {
 				if (is_subnetv6($subnet)) {
 					$radvdconf .= "\tprefix {$subnet} {\n";
 					$radvdconf .= "\t\tDeprecatePrefix on;\n";
+					$_subnet_adv_autonomous = (substr(rtrim($subnet), -3) == '/64') ? "on" : "off";
 					switch ($dhcpv6ifconf['ramode']) {
 						case "managed":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
@@ -225,11 +227,11 @@ function services_radvd_configure($blacklist = array()) {
 							break;
 						case "assist":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
-							$radvdconf .= "\t\tAdvAutonomous on;\n";
+							$radvdconf .= "\t\tAdvAutonomous $_subnet_adv_autonomous;\n";
 							break;
 						case "unmanaged":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
-							$radvdconf .= "\t\tAdvAutonomous on;\n";
+							$radvdconf .= "\t\tAdvAutonomous $_subnet_adv_autonomous;\n";
 							break;
 					}
 					$radvdconf .= "\t};\n";


### PR DESCRIPTION
Some of our intefaces have both a /64 and a /112 address configured.  We
only want to autoconfigure on the /64. (Autoconfigure only works on /64s
anyway.) Not setting the autonomous flag on the /112 prevents the
spewage of "IPv6 addrconf: prefix with wrong length 112" messages in the
syslog of older linuxes.

