### PR TITLE
radvd.conf: configure extra subnets in "router only" mode

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -214,10 +214,13 @@ function services_radvd_configure($blacklist = array()) {
 				if (is_subnetv6($subnet)) {
 					$radvdconf .= "\tprefix {$subnet} {\n";
 					$radvdconf .= "\t\tDeprecatePrefix on;\n";
+					/*
 					switch ($dhcpv6ifconf['ramode']) {
 						case "managed":
+					*/
 							$radvdconf .= "\t\tAdvOnLink on;\n";
 							$radvdconf .= "\t\tAdvAutonomous off;\n";
+					/*
 							break;
 						case "router":
 							$radvdconf .= "\t\tAdvOnLink off;\n";
@@ -232,6 +235,7 @@ function services_radvd_configure($blacklist = array()) {
 							$radvdconf .= "\t\tAdvAutonomous on;\n";
 							break;
 					}
+					*/
 					$radvdconf .= "\t};\n";
 				}
 			}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -214,28 +214,36 @@ function services_radvd_configure($blacklist = array()) {
 				if (is_subnetv6($subnet)) {
 					$radvdconf .= "\tprefix {$subnet} {\n";
 					$radvdconf .= "\t\tDeprecatePrefix on;\n";
-					/*
 					switch ($dhcpv6ifconf['ramode']) {
 						case "managed":
-					*/
 							$radvdconf .= "\t\tAdvOnLink on;\n";
 							$radvdconf .= "\t\tAdvAutonomous off;\n";
-					/*
 							break;
 						case "router":
 							$radvdconf .= "\t\tAdvOnLink off;\n";
 							$radvdconf .= "\t\tAdvAutonomous off;\n";
 							break;
 						case "assist":
+							$radvdconf .= "\t\t# ramode = assist\n";
 							$radvdconf .= "\t\tAdvOnLink on;\n";
-							$radvdconf .= "\t\tAdvAutonomous on;\n";
+							/* Disable autonomous unless 64 bit subnet */
+				        		if (preg_match('#/(?!64$)(\d+)$#', $subnet)) {
+							  $radvdconf .= "\t\tAdvAutonomous off;\n";
+							} else {
+							  $radvdconf .= "\t\tAdvAutonomous on;\n";
+							}
 							break;
 						case "unmanaged":
+							$radvdconf .= "\t\t# ramode = unmanaged\n";
 							$radvdconf .= "\t\tAdvOnLink on;\n";
-							$radvdconf .= "\t\tAdvAutonomous on;\n";
+							/* Disable autonomous unless 64 bit subnet */
+				        		if (preg_match('#/(?!64$)(\d+)$#', $subnet)) {
+							  $radvdconf .= "\t\tAdvAutonomous off;\n";
+							} else {
+							  $radvdconf .= "\t\tAdvAutonomous on;\n";
+							}
 							break;
 					}
-					*/
 					$radvdconf .= "\t};\n";
 				}
 			}


### PR DESCRIPTION
Configure any additional subnets in "managed" mode (clear the *autonomous* bits for any extra prefixes).
